### PR TITLE
Adding a new <port> configuration item for Derby

### DIFF
--- a/src/main/java/com/btmatthews/maven/plugins/inmemdb/db/AbstractDatabase.java
+++ b/src/main/java/com/btmatthews/maven/plugins/inmemdb/db/AbstractDatabase.java
@@ -65,6 +65,11 @@ public abstract class AbstractDatabase extends AbstractServer implements Databas
     private String databasePassword;
 
     /**
+     * The port number used for the database (not supported by all databases)
+     */
+    private int port;
+
+    /**
      * Configure the server.
      *
      * @param name   Name of the configuration property.
@@ -82,6 +87,9 @@ public abstract class AbstractDatabase extends AbstractServer implements Databas
         } else if ("password".equals(name)) {
             logger.logInfo("Configured database password: " + value);
             databasePassword = (String)value;
+        } else if ("port".equals(name)) {
+            logger.logInfo("Configured database port: " + value);
+            port = new Integer(value.toString());
         }
     }
 
@@ -114,6 +122,24 @@ public abstract class AbstractDatabase extends AbstractServer implements Databas
         } else {
             return databasePassword;
         }
+    }
+
+    /**
+     * Get the port number used in the database connection URL
+     *
+     * @return database port number
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Set the port number used in the database connection URL
+     *
+     * @param port port number
+     */
+    public void setPortNumber(int port) {
+        this.port = port;
     }
 
     /**
@@ -151,4 +177,5 @@ public abstract class AbstractDatabase extends AbstractServer implements Databas
             }
         }
     }
+
 }

--- a/src/main/java/com/btmatthews/maven/plugins/inmemdb/db/derby/DerbyDatabase.java
+++ b/src/main/java/com/btmatthews/maven/plugins/inmemdb/db/derby/DerbyDatabase.java
@@ -16,9 +16,10 @@
 
 package com.btmatthews.maven.plugins.inmemdb.db.derby;
 
-import javax.sql.DataSource;
 import java.io.PrintWriter;
+import java.net.InetAddress;
 import java.sql.Connection;
+import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,10 +47,9 @@ import org.apache.derby.jdbc.ClientDriver;
 public final class DerbyDatabase extends AbstractSQLDatabase {
 
     /**
-     * The connection protocol for in-memory Apache Derby databases.
+     * Default port Derby listens on, can be altered via setting port property
      */
-    //private static final String PROTOCOL = "derby:memory:";
-    private static final String PROTOCOL = "derby://localhost/memory:";
+    private static final int DEFAULT_PORT = 1527;
 
     /**
      * The value of the additional connection parameter which will cause the
@@ -76,12 +76,12 @@ public final class DerbyDatabase extends AbstractSQLDatabase {
     private NetworkServerControl server;
 
     /**
-     * Get the database connection protocol.
+     * Get the database connection protocol used for JDBC connections
      *
-     * @return Always returns {@link DerbyDatabase#PROTOCOL}.
+     * @return Returns protocol
      */
     protected String getUrlProtocol() {
-        return PROTOCOL;
+        return "derby://localhost:" + (getPort() > 0 ? getPort() : DEFAULT_PORT) + "/memory:";
     }
 
     /**
@@ -124,7 +124,7 @@ public final class DerbyDatabase extends AbstractSQLDatabase {
         assert logger != null;
 
         try {
-            server = new NetworkServerControl();
+            server = new NetworkServerControl(InetAddress.getByName("localhost"), (getPort() > 0 ? getPort() : DEFAULT_PORT));
             server.start(new PrintWriter(System.out));
         } catch (final Exception e) {
             return;

--- a/src/main/java/com/btmatthews/maven/plugins/inmemdb/mojo/RunMojo.java
+++ b/src/main/java/com/btmatthews/maven/plugins/inmemdb/mojo/RunMojo.java
@@ -69,6 +69,12 @@ public final class RunMojo extends AbstractRunMojo {
     private String password = "";
 
     /**
+     * The port for database connections.
+     */
+    @Parameter(property = "inmemdb.port", defaultValue = "")
+    private String port;
+
+    /**
      * Get the server type.
      *
      * @return The value of {@link #type}.
@@ -79,7 +85,7 @@ public final class RunMojo extends AbstractRunMojo {
     }
 
     /**
-     * Get the server configuration parameters. These are {@link #database}, {@link #username} and {@link #password}.
+     * Get the server configuration parameters. These are {@link #database}, {@link #port}, {@link #username} and {@link #password}.
      *
      * @return A {@link Map} containing the configuration parameters.
      */
@@ -88,6 +94,9 @@ public final class RunMojo extends AbstractRunMojo {
         final Map<String, Object> config = new HashMap<String, Object>();
         config.put("database", database);
         config.put("username", username);
+        if (port != null && !port.isEmpty()) {
+            config.put("port", port);
+        }
         if (password == null) {
             config.put("password", "");
         } else {


### PR DESCRIPTION
The plugin is presently hardcoded to use Derby's default port 1527.  This PR allows for different ports by adding a <port> config item.  For opensource projects, some devs may be reluctant to use port 1527 out of concern that a downloader may already be using that port for Derby, so they configure tests to use a nonstandard port instead (but even if not, providing a setting allows an individual dev to change the port if necessary for his machine.)  Providing this option is particularly helpful here because even though the plugin will work if 1527 was previously activated by another process, the stop mojo will end up shutting down the Derby at that port, affecting other processes using it.  Note: this <port> option will not presently do anything for databases supported by inmemdb other than Derby.  I tested this change on Apache Roller, it worked fine, but not the test cases, as I couldn't get them to run for some reason on my machine, change or no change.  To test, just set the <port/> value and then connect to the database using a URL of jdbc:derby://localhost:PORT#/memory:mydb.
